### PR TITLE
fix(fix #161): higlight active or focused links

### DIFF
--- a/src/scenes/Search/SearchResults.module.scss
+++ b/src/scenes/Search/SearchResults.module.scss
@@ -23,6 +23,15 @@
 
   &:focus {
     opacity: 1 !important;
+    color: $object;
+  }
+
+  &:active {
+    color: $object;
+  }
+
+  &:hover {
+    color: $object;
   }
 
   &:focus-visible {


### PR DESCRIPTION
Search result links was not highlited neiter in focus nor usin up/down arrow buttons. It was seemed
like bug with highliting. For better UX highliting was added

fix #161